### PR TITLE
Simplify README and move contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
 # .github
 
-
-test
+Organization-wide GitHub configurations and profile documentation for KahitSan Solutions Corp. This repository contains shared GitHub Actions workflows, issue templates, pull request templates, and the organization's public profile that appears on our GitHub organization page.

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,12 +1,4 @@
-# KahitSan Solutions Corp
-
-**Productivity starts anywhere.** Your comfy study tambayan.
-
----
-
-## Overview
-
-KahitSan Solutions Corp is building a network of productivity tools and spaces, from coworking hubs in Naga City to modern software solutions that empower developers and connect communities.
+We are building a network of productivity tools and spaces, from coworking hubs in Naga City to modern software solutions that empower developers and connect communities.
 
 **Coworking Spaces:**
 


### PR DESCRIPTION
Cleaned up the profile README by removing Getting Started and Technology Stack sections. Contributors can find that info in the Contributing Guide. Moved Contributing section to the bottom with a concise description.